### PR TITLE
Only use rails-ujs

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,6 @@
 // about supported directives.
 //
 //= require jquery3
-//= require jquery_ujs
 //= require rails-ujs
 //= require activestorage
 //= require turbolinks


### PR DESCRIPTION
Hotfix: Fix `Uncaught Error: If you load both jquery_ujs and rails-ujs, use rails-ujs only.` error.